### PR TITLE
README表記修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ flutter build <platform> --release
 
 ```bash
 flutter test
-
+```
 
 
 ## ライセンス


### PR DESCRIPTION
## 概要
`README.md` 内において、コードブロック（ ``` ）が適切に閉じられていない箇所がありました。
この影響で、該当箇所より下のテキストがすべてコードブロックとして表示されるという表示崩れが発生していたため、修正を行いました。

## 修正内容
- `README.md` のコードブロック末尾に閉じ記号（ ``` ）を追加。

## チケット
 close #23 