### PR TITLE
位置情報取得不可ダイアログ実装

### DIFF
--- a/lib/component/location_error_dialog.dart
+++ b/lib/component/location_error_dialog.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-/// 位置情報エラーを通知し、OSの設定画面へ誘導する
-Future<void> showLocationErrorDialog(BuildContext context) {
-  return showDialog<void>(
-    context: context,
-    builder: (context) => AlertDialog(
+class LocationErrorDialog extends StatelessWidget {
+  const LocationErrorDialog({super.key});
+
+  /// 位置情報エラーを通知し、OSの設定画面へ誘導する
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
       title: const Text(
         '位置情報を取得できません',
         style: TextStyle(fontWeight: FontWeight.bold),
@@ -26,6 +28,6 @@ Future<void> showLocationErrorDialog(BuildContext context) {
           child: const Text('設定を開く'),
         ),
       ],
-    ),
-  );
+    );
+  }
 }

--- a/lib/page/main_home_page.dart
+++ b/lib/page/main_home_page.dart
@@ -67,7 +67,10 @@ class MainHomePage extends HookConsumerWidget {
                     } catch (e) {
                       // 失敗した時だけダイアログを出す
                       if (context.mounted) {
-                        showLocationErrorDialog(context);
+                        showDialog(
+                          context: context,
+                          builder: (context) => const LocationErrorDialog(),
+                        );
                       }
                     }
                   },


### PR DESCRIPTION
# 位置情報取得失敗時のエラーダイアログ実装

## 概要
現在地の天気取得ボタンを押した際、位置情報の権限拒否だった場合のダイアログ表示を実装しました。

## 内容
-  位置情報エラー専用のダイアログ`showLocationErrorDialog`を作成しました。
- ダイアログの「設定を開く」ボタンから、OSのアプリ設定画面へ直接遷移できる機能を `permission_handler` を用いて実装しました。
- 現在地の天気を見るボタンを押した際に、位置取得失敗時にダイアログを表示するロジックを実装。
- 位置取得の失敗をView側で検知し、設定画面への誘導ダイアログを出せるように整理しました。

## 確認事項
- 位置情報の権限を「許可しない」にした場合、エラーダイアログが表示される。
- ダイアログの「設定を開く」を押した際、OSの設定画面へ遷移する。
- ダイアログの「閉じる」を押して正常に閉じることができる。

## チケット
close #12 

## 動作確認

### Android(Pixel6)

https://github.com/user-attachments/assets/85fb2e64-6a00-479c-b090-3e432bf5e730

### iOS(iPhone17)

https://github.com/user-attachments/assets/af061917-6357-44c1-bbe7-c90d3d1cdbf3
