### PR TITLE
LocationRepositoryのユニットテスト

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ flutter run -d web       # Web
 - **[riverpod_generator](https://riverpod.dev/ja/docs/introduction/getting_started)**: 状態管理ライブラリ。データの保持や共有を簡単に行い、面倒な定義コードを自動生成する。
 - **[build_runnner](https://riverpod.dev/ja/docs/introduction/getting_started)**: 状態管理ライブラリ。データの保持や共有を簡単にするため、アノテーションを元にして必要なプログラムを自動生成する実行機。
 - **[dio](https://pub.dev/packages/dio)**: HTTPリクエストを簡単かつ便利に行う。
-- **[permission_handler](https://pub.dev/packages/permission_handler)**:デバイスの権限管理ライブラリ。位置情報、カメラ、通知などの利用許可の状態確認や、ユーザーへの要求を行う。
-- **[geolocator](https://pub.dev/packages/geolocator)**:位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
-- **[geocoding](https://pub.dev/packages/geocoding/install)**:緯度経度を都市名に、都市名を緯度経度に変換する。
-- **[mocktail](https://pub.dev/packages/mocktail)**:ユニットテストでAPI通信やデータベースなどの依存関係を模倣する軽量なライブラリ。
-- **[plugin_platform_interface](https://pub.dev/packages/plugin_platform_interface)**:geocodingなどのOS依存プラグインを安全にモック化するための公式ユーティリティ。テスト時に発生するプラットフォーム制限（Assertion Error）を回避するために導入
+- **[permission_handler](https://pub.dev/packages/permission_handler)**: デバイスの権限管理ライブラリ。位置情報、カメラ、通知などの利用許可の状態確認や、ユーザーへの要求を行う。
+- **[geolocator](https://pub.dev/packages/geolocator)**: 位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
+- **[geocoding](https://pub.dev/packages/geocoding/install)**: 緯度経度を都市名に、都市名を緯度経度に変換する。
+- **[mocktail](https://pub.dev/packages/mocktail)**: ユニットテストでAPI通信やデータベースなどの依存関係を模倣する軽量なライブラリ。
+- **[plugin_platform_interface](https://pub.dev/packages/plugin_platform_interface)**: geocodingなどのOS依存プラグインを安全にモック化するための公式ユーティリティ。テスト時に発生するプラットフォーム制限（Assertion Error）を回避するために導入
 
 ### 開発用依存関係
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ flutter run -d web       # Web
 - **[riverpod_generator](https://riverpod.dev/ja/docs/introduction/getting_started)**: 状態管理ライブラリ。データの保持や共有を簡単に行い、面倒な定義コードを自動生成する。
 - **[build_runnner](https://riverpod.dev/ja/docs/introduction/getting_started)**: 状態管理ライブラリ。データの保持や共有を簡単にするため、アノテーションを元にして必要なプログラムを自動生成する実行機。
 - **[dio](https://pub.dev/packages/dio)**: HTTPリクエストを簡単かつ便利に行う。
-- **[permission_hundler]**:デバイスの権限管理ライブラリ。位置情報、カメラ、通知などの利用許可の状態確認や、ユーザーへの要求を行う。
-- **[geolocater](https://pub.dev/packages/geolocator)**:位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
-- **[geocording](https://pub.dev/packages/geocoding/install)**:緯度経度を都市名に、都市名を緯度経度に変換する。
+- **[permission_handler](https://pub.dev/packages/permission_handler)**:デバイスの権限管理ライブラリ。位置情報、カメラ、通知などの利用許可の状態確認や、ユーザーへの要求を行う。
+- **[geolocator](https://pub.dev/packages/geolocator)**:位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
+- **[geocoding](https://pub.dev/packages/geocoding/install)**:緯度経度を都市名に、都市名を緯度経度に変換する。
 - **[mocktail](https://pub.dev/packages/mocktail)**:ユニットテストでAPI通信やデータベースなどの依存関係を模倣する軽量なライブラリ。
 - **[plugin_platform_interface](https://pub.dev/packages/plugin_platform_interface)**:geocodingなどのOS依存プラグインを安全にモック化するための公式ユーティリティ。テスト時に発生するプラットフォーム制限（Assertion Error）を回避するために導入
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ flutter run -d web       # Web
 - **[permission_hundler]**:デバイスの権限管理ライブラリ。位置情報、カメラ、通知などの利用許可の状態確認や、ユーザーへの要求を行う。
 - **[geolocater](https://pub.dev/packages/geolocator)**:位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
 - **[geocording](https://pub.dev/packages/geocoding/install)**:緯度経度を都市名に、都市名を緯度経度に変換する。
+- **[mocktail](https://pub.dev/packages/mocktail)**:ユニットテストでAPI通信やデータベースなどの依存関係を模倣する軽量なライブラリ。
 
 ### 開発用依存関係
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ flutter run -d web       # Web
 - **[geolocater](https://pub.dev/packages/geolocator)**:位置情報操作ライブラリ。デバイスのGPSから現在地の緯度・経度を取得したり、ユーザーの位置情報利用許可を管理したりするための仲介機。
 - **[geocording](https://pub.dev/packages/geocoding/install)**:緯度経度を都市名に、都市名を緯度経度に変換する。
 - **[mocktail](https://pub.dev/packages/mocktail)**:ユニットテストでAPI通信やデータベースなどの依存関係を模倣する軽量なライブラリ。
+- **[plugin_platform_interface](https://pub.dev/packages/plugin_platform_interface)**:geocodingなどのOS依存プラグインを安全にモック化するための公式ユーティリティ。テスト時に発生するプラットフォーム制限（Assertion Error）を回避するために導入
 
 ### 開発用依存関係
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -713,7 +713,7 @@ packages:
     source: hosted
     version: "7.0.1"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -608,6 +608,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.3"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
   build_runner: ^2.11.1
   freezed: ^3.2.3
   json_serializable: ^6.11.2
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dev_dependencies:
   freezed: ^3.2.3
   json_serializable: ^6.11.2
   mocktail: ^1.0.4
+  plugin_platform_interface: ^2.1.8
 
 flutter:
   uses-material-design: true

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:geocoding/geocoding.dart' as geo;
+import 'package:weather_app_v2/repository/location_repository.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+// geocodingがimplementsだけだと怒られたのでMockPlatformInterfaceMixinを追加
+class MockGeocodingPlatform extends Mock
+    with
+        MockPlatformInterfaceMixin // 公式のすり替え許可証。withで機能を混ぜる
+    implements geo.GeocodingPlatform {} // 本物のメソッドの形だけ借りる
+
+void main() {
+  // setUpで初期化して使い回したいのでlateで宣言
+  late LocationRepository repository; // テスト対象の本物
+  late MockGeocodingPlatform mockGeocoding; // 操作するための偽物
+
+  setUp(() {
+    repository = LocationRepository();
+    mockGeocoding = MockGeocodingPlatform();
+    geo.GeocodingPlatform.instance = mockGeocoding;
+
+    // 言語設定はとりあえずモックしておく。any()でどんな引数もキャッチ
+    when(
+      () => mockGeocoding.setLocaleIdentifier(any()),
+    ).thenAnswer((_) async => {}); // 何もしない
+  });
+
+  group('getCurrentLocationDataのテスト', () {
+    // 東京駅の座標
+    const tLat = 35.681; // t: test用の
+    const tLon = 139.7671;
+
+    test('localityが取れるならそれを返す', () async {
+      final tPlacemark = geo.Placemark(
+        locality: '千代田区',
+        administrativeArea: '東京都',
+      );
+      when(
+        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+      ).thenAnswer((_) async => [tPlacemark]);
+
+      final result = await repository.getCurrentLocationData(
+        lat: tLat,
+        lon: tLon,
+      );
+
+      expect(result.name, '千代田区');
+    });
+
+    test('localityがnullのときは都道府県を返す', () async {
+      final tPlacemark = geo.Placemark(
+        locality: null,
+        administrativeArea: '東京都',
+      );
+      when(
+        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+      ).thenAnswer((_) async => [tPlacemark]);
+
+      final result = await repository.getCurrentLocationData(
+        lat: tLat,
+        lon: tLon,
+      );
+
+      expect(result.name, '東京都');
+    });
+
+    test('住所がどっちもnullなら「現在地」', () async {
+      final tPlacemark = geo.Placemark(
+        locality: null,
+        administrativeArea: null,
+      );
+      when(
+        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+      ).thenAnswer((_) async => [tPlacemark]);
+
+      final result = await repository.getCurrentLocationData(
+        lat: tLat,
+        lon: tLon,
+      );
+
+      expect(result.name, '現在地');
+    });
+
+    test('エラーのときは専用のメッセージを投げるか', () async {
+      when(
+        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+      ).thenThrow(Exception('Service Error'));
+
+      expect(
+        () => repository.getCurrentLocationData(lat: tLat, lon: tLon),
+        // throwA:今からエラーが起こるという予想を待ち構える
+        throwsA(
+          //isA<Exception>:エラーがexeptionである確認　having:エラーの中身を詳しく調べる
+          isA<Exception>().having(
+            (error) => error.toString(), // エラーの文字を取り出す
+            '',
+            contains('住所が見つかりませんでした'), // エラーにこの文字が入っているか
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -10,6 +10,10 @@ class MockGeocodingPlatform extends Mock
         MockPlatformInterfaceMixin // 公式のすり替え許可証。withで機能を混ぜる
     implements geo.GeocodingPlatform {} // 本物のメソッドの形だけ借りる
 
+// 元の GeocodingPlatform.instance を保持しておく
+final geo.GeocodingPlatform? _originalGeocodingPlatformInstance =
+    geo.GeocodingPlatform.instance;
+
 void main() {
   // setUpで初期化して使い回したいのでlateで宣言
   late LocationRepository repository; // テスト対象の本物
@@ -19,6 +23,11 @@ void main() {
     repository = LocationRepository();
     mockGeocoding = MockGeocodingPlatform();
     geo.GeocodingPlatform.instance = mockGeocoding;
+
+    // 各テスト終了後に元の instance に戻す
+    addTearDown(() {
+      geo.GeocodingPlatform.instance = _originalGeocodingPlatformInstance;
+    });
 
     // 言語設定はとりあえずモックしておく。any()でどんな引数もキャッチ
     when(

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -40,74 +40,78 @@ void main() {
     const tLat = 35.681; // t: test用の
     const tLon = 139.7671;
 
-    test('localityが取れるならそれを返す', () async {
-      final tPlacemark = geo.Placemark(
-        locality: '千代田区',
-        administrativeArea: '東京都',
-      );
-      when(
-        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
-      ).thenAnswer((_) async => [tPlacemark]);
+    group('正常系のテスト', () {
+      test('localityが取れるならそれを返す', () async {
+        final tPlacemark = geo.Placemark(
+          locality: '千代田区',
+          administrativeArea: '東京都',
+        );
+        when(
+          () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+        ).thenAnswer((_) async => [tPlacemark]);
 
-      final result = await repository.getCurrentLocationData(
-        lat: tLat,
-        lon: tLon,
-      );
+        final result = await repository.getCurrentLocationData(
+          lat: tLat,
+          lon: tLon,
+        );
 
-      expect(result.name, '千代田区');
+        expect(result.name, '千代田区');
+      });
+
+      test('localityがnullのときは都道府県を返す', () async {
+        final tPlacemark = geo.Placemark(
+          locality: null,
+          administrativeArea: '東京都',
+        );
+        when(
+          () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+        ).thenAnswer((_) async => [tPlacemark]);
+
+        final result = await repository.getCurrentLocationData(
+          lat: tLat,
+          lon: tLon,
+        );
+
+        expect(result.name, '東京都');
+      });
+
+      test('住所がどっちもnullなら「現在地」', () async {
+        final tPlacemark = geo.Placemark(
+          locality: null,
+          administrativeArea: null,
+        );
+        when(
+          () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+        ).thenAnswer((_) async => [tPlacemark]);
+
+        final result = await repository.getCurrentLocationData(
+          lat: tLat,
+          lon: tLon,
+        );
+
+        expect(result.name, '現在地');
+      });
     });
 
-    test('localityがnullのときは都道府県を返す', () async {
-      final tPlacemark = geo.Placemark(
-        locality: null,
-        administrativeArea: '東京都',
-      );
-      when(
-        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
-      ).thenAnswer((_) async => [tPlacemark]);
+    group('異常系のテスト', () {
+      test('エラーのときはExceptionを投げるか', () async {
+        when(
+          () => mockGeocoding.placemarkFromCoordinates(any(), any()),
+        ).thenThrow(Exception('Service Error'));
 
-      final result = await repository.getCurrentLocationData(
-        lat: tLat,
-        lon: tLon,
-      );
-
-      expect(result.name, '東京都');
-    });
-
-    test('住所がどっちもnullなら「現在地」', () async {
-      final tPlacemark = geo.Placemark(
-        locality: null,
-        administrativeArea: null,
-      );
-      when(
-        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
-      ).thenAnswer((_) async => [tPlacemark]);
-
-      final result = await repository.getCurrentLocationData(
-        lat: tLat,
-        lon: tLon,
-      );
-
-      expect(result.name, '現在地');
-    });
-
-    test('エラーのときはExceptionを投げるか', () async {
-      when(
-        () => mockGeocoding.placemarkFromCoordinates(any(), any()),
-      ).thenThrow(Exception('Service Error'));
-
-      expect(
-        () => repository.getCurrentLocationData(lat: tLat, lon: tLon),
-        // throwA:今からエラーが起こるという予想を待ち構える
-        throwsA(
-          //isA<Exception>:エラーがexceptionである確認　having:エラーの中身を詳しく調べる
-          isA<Exception>().having(
-            (error) => error.toString(), // エラーの文字を取り出す
-            '',
-            contains('住所が見つかりませんでした'), // エラーにこの文字が入っているか
+        expect(
+          () => repository.getCurrentLocationData(lat: tLat, lon: tLon),
+          // throwA:今からエラーが起こるという予想を待ち構える
+          throwsA(
+            //isA<Exception>:エラーがexceptionである確認　having:エラーの中身を詳しく調べる
+            isA<Exception>().having(
+              (error) => error.toString(), // エラーの文字を取り出す
+              '',
+              contains('住所が見つかりませんでした'), // エラーにこの文字が入っているか
+            ),
           ),
-        ),
-      );
+        );
+      });
     });
   });
 }

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -100,7 +100,7 @@ void main() {
         () => repository.getCurrentLocationData(lat: tLat, lon: tLon),
         // throwA:今からエラーが起こるという予想を待ち構える
         throwsA(
-          //isA<Exception>:エラーがexeptionである確認　having:エラーの中身を詳しく調べる
+          //isA<Exception>:エラーがexceptionである確認　having:エラーの中身を詳しく調べる
           isA<Exception>().having(
             (error) => error.toString(), // エラーの文字を取り出す
             '',

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -91,7 +91,7 @@ void main() {
       expect(result.name, '現在地');
     });
 
-    test('エラーのときは専用のメッセージを投げるか', () async {
+    test('エラーのときはExceptionを投げるか', () async {
       when(
         () => mockGeocoding.placemarkFromCoordinates(any(), any()),
       ).thenThrow(Exception('Service Error'));

--- a/test/location_repository_test.dart
+++ b/test/location_repository_test.dart
@@ -23,7 +23,7 @@ void main() {
     // 言語設定はとりあえずモックしておく。any()でどんな引数もキャッチ
     when(
       () => mockGeocoding.setLocaleIdentifier(any()),
-    ).thenAnswer((_) async => {}); // 何もしない
+    ).thenAnswer((_) async {}); // 何もしない
   });
 
   group('getCurrentLocationDataのテスト', () {


### PR DESCRIPTION
# LocationRepositoryのユニットテスト実装

## 概要
現在地住所取得ロジックのユニットテストを実装しました。


## 内容
- 外部パッケージの `geocoding` を使っている部分を `mocktail` でモック化してテストしています。
- プラグインの制限（Assertion Error）の回避のため、`plugin_platform_interface` を導入しました。

以下の4パターンをテストしています：
- 市区町村が取得できたときに、その名前を返すか
- 市区町村がnullでも、都道府県名を代わりに返すか
- 両方nullの場合に「現在地」という文字を返すか
- エラーが発生したときに、自作のエラーメッセージを投げているか

## 確認事項
- `flutter test` を実行し、全4件のテストがパスすること（`+4: All tests passed!`）を確認しました。
- 異常系のテストにおいて、期待通りのエラーメッセージが含まれていることを確認しました。

## チケット
close #40 

## 動作確認

### ターミナル実行結果
<img width="598" height="148" alt="スクリーンショット 2026-03-13 15 57 48" src="https://github.com/user-attachments/assets/e7889aba-e3bc-4701-8d1d-9f7c565fe5f3" />
